### PR TITLE
Added support for optional Module parameter in the instantiate function.

### DIFF
--- a/lib/react-unity-webgl.js
+++ b/lib/react-unity-webgl.js
@@ -78,7 +78,8 @@ var Unity = function (_Component) {
                         loaded: progress == 1,
                         progress: progress
                     });
-                }
+                },
+                Module: this.props.module
             });
             module.exports.UnityInstance = instance;
         }

--- a/source/react-unity-webgl.js
+++ b/source/react-unity-webgl.js
@@ -54,7 +54,7 @@ class Unity extends Component {
                         progress: progress
                     });
                 }),
-				Module : this.props.module
+                Module : this.props.module
             });
         module.exports.UnityInstance = instance;
     }

--- a/source/react-unity-webgl.js
+++ b/source/react-unity-webgl.js
@@ -53,7 +53,8 @@ class Unity extends Component {
                         loaded: progress == 1,
                         progress: progress
                     });
-                })
+                }),
+				Module : this.props.module
             });
         module.exports.UnityInstance = instance;
     }


### PR DESCRIPTION
UnityLoader allows to override Module properties when calling instantiate function (see reference : https://docs.unity3d.com/Manual/webgl-templates.html).

This allows to give dynamic path for some of the properties instead of a simple JSON file when running in an environment such as Electron.

Source file has been compiled.