### PR TITLE
Support for Server Side Rending Modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-unity-webgl",
-  "version": "8.0.2",
+  "version": "8.1.0",
   "description": "React Unity WebGL provides an easy solution for embedding Unity WebGL builds in your React application, with two-way communication between your React and Unity application with advanced API's.",
   "main": "./distribution/exports.js",
   "scripts": {


### PR DESCRIPTION
This Pull-Request adds support for Server Side Rending Modules such as NextJS. Note that this will NOT render the Unity Application on the Server but is simply not appending the Unity component during SSR. The Unity Component will be instantiated when the application is being rendering on the client side.