### PR TITLE
fix canvas event reference

### DIFF
--- a/source/components/unity.ts
+++ b/source/components/unity.ts
@@ -66,8 +66,8 @@ export function Unity(props: IUnityProps): ReactElement {
         // When the application is loaded, we'll send over a reference to the
         // canvas element. When the HTML Canvas Element ref is defined, an event
         // will be dispatched.
-        if (htmlCanvasElement !== null) {
-          unityContext.dispatchEvent("canvas", htmlCanvasElement);
+        if (htmlCanvasElement.current !== null) {
+          unityContext.dispatchEvent("canvas", htmlCanvasElement.current);
         }
         // The loaded event is dispatched.
         unityContext.dispatchEvent("loaded");


### PR DESCRIPTION
fix a regression introduced in bec2c654acdd5954527482882e1ea2f6f32c6429,
where the canvas event was dispatched with the react ref, rather than
the underlying canvas value.
