### PR TITLE
fix distribution location absolute to relative

### DIFF
--- a/module/package.json
+++ b/module/package.json
@@ -28,8 +28,8 @@
       "url": "https://paypal.me/jeffreylanters"
     }
   ],
-  "main": "/distribution/exports.js",
-  "types": "/distribution/exports.d.ts",
+  "main": "./distribution/exports.js",
+  "types": "./distribution/exports.d.ts",
   "browserslist": {
     "production": [
       ">0.2%",


### PR DESCRIPTION
```bash
yarn build && yarn start
yarn run v1.22.18
warning package.json: No license field
$ next build
warn  - SWC minify release candidate enabled. https://nextjs.org/docs/messages/swc-minify-enabled
info  - Checking validity of types
info  - Need to disable some ESLint rules? Learn more here: https://nextjs.org/docs/basic-features/eslint#disabling-rules

🌼 daisyUI components 2.15.3  https://github.com/saadeghi/daisyui
  ✔︎ Including:  base, components, themes[29], utilities

info  - Creating an optimized production build
info  - Compiled successfully
info  - Collecting page data
info  - Generating static pages (2/2)
info  - Finalizing page optimization

Page                                       Size     First Load JS
┌ λ /                                      3.34 kB          79 kB
├   /_app                                  0 B            75.6 kB
├ ○ /404                                   179 B          75.8 kB
└ λ /api                                   0 B            75.6 kB
+ First Load JS shared by all              75.6 kB
  ├ chunks/framework-3d30821d81ba4e57.js   45.1 kB
  ├ chunks/main-b5f11cd63dbd0d26.js        29.1 kB
  ├ chunks/pages/_app-90f084dafbabde1d.js  651 B
  ├ chunks/webpack-6124748274e43398.js     765 B
  └ css/0f9c296d0a5c912b.css               13.7 kB

λ  (Server)  server-side renders at runtime (uses getInitialProps or getServerSideProps)
○  (Static)  automatically rendered as static HTML (uses no initial props)

✨  Done in 7.68s.
yarn run v1.22.18
warning package.json: No license field
$ next start
ready - started server on 0.0.0.0:3000, url: http://localhost:3000
warn  - SWC minify release candidate enabled. https://nextjs.org/docs/messages/swc-minify-enabled
Error: Cannot find module '/distribution/exports.js'. Please verify that the package.json has a valid "main" entry
    at tryPackage (node:internal/modules/cjs/loader:353:19)
    at Function.Module._findPath (node:internal/modules/cjs/loader:566:18)
    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:919:27)
    at Function.mod._resolveFilename (/Users/benjioh5/Coding/webgl/node_modules/next/dist/build/webpack/require-hook.js:183:28)
    at Function.Module._load (node:internal/modules/cjs/loader:778:27)
    at Module.require (node:internal/modules/cjs/loader:1005:19)
    at require (node:internal/modules/cjs/helpers:102:18)
    at Object.172 (/Users/benjioh5/Coding/webgl/.next/server/pages/index.js:22:52)
    at __webpack_require__ (/Users/benjioh5/Coding/webgl/.next/server/webpack-runtime.js:25:42)
    at __webpack_exec__ (/Users/benjioh5/Coding/webgl/.next/server/pages/index.js:69:39) {
  code: 'MODULE_NOT_FOUND',
  path: '/Users/benjioh5/Coding/webgl/node_modules/react-unity-webgl/package.json',
  requestPath: 'react-unity-webgl'
}
```

using absolute path on package.json cause error.