### PR TITLE
Fixed event return value not being returned (#40 regression)

### DIFF
--- a/module/source/hooks/use-event-system.ts
+++ b/module/source/hooks/use-event-system.ts
@@ -22,11 +22,17 @@ const mountedEventDispatchers: ((
 const dispatchReactUnityEvent = (
   eventName: string,
   ...parameters: ReactUnityEventParameterType[]
-): void =>
+): void => {
   // Loops through all of the mounted event systems and dispatches the event.
-  mountedEventDispatchers.forEach((dispatchEvent) =>
-    dispatchEvent(eventName, ...parameters)
-  );
+  // In case there are multiple event systems, the return value
+  // origin is undefined.
+  let returnValue: any = undefined;
+  mountedEventDispatchers.forEach((dispatchEvent) => {
+    returnValue = dispatchEvent(eventName, ...parameters);
+  });
+
+  return returnValue;
+}
 
 if (isBrowserEnvironment === true) {
   // It is possible for the application being rendered server side. We'll check
@@ -112,7 +118,7 @@ const useEventSystem = (): IEventSystemHook => {
         return;
       }
       // The event listener will be invoked with the parameters.
-      eventListener.callback(...parameters);
+      return eventListener.callback(...parameters);
     },
     [eventListeners]
   );


### PR DESCRIPTION
Somewhere during the v9.x refactor, a regression was introduced that made it not possible to return values from an event back to Unity. This PR fixes that and makes this feature work again.

Reference:
https://github.com/jeffreylanters/react-unity-webgl/issues/40
https://github.com/jeffreylanters/react-unity-webgl/pull/41
https://github.com/jeffreylanters/react-unity-webgl/pull/42

P.S. I feel like "event" was a poor choice of word, it implies just firing and forgetting. However, it's really more like a bound function, and functions surely can return values.