### PR TITLE
Fix matchWebGLToCanvasSize not setting to false

### DIFF
--- a/module/source/hooks/use-unity-arguments.ts
+++ b/module/source/hooks/use-unity-arguments.ts
@@ -51,7 +51,10 @@ const useUnityArguments = (unityProps: UnityProps): UnityArguments => {
       // Assigns the match WebGL to canvas size value to the Unity arguments
       // object. If the match WebGL to canvas size value is not defined via the
       // Unity Props, the default value of `true` will be used.
-      matchWebGLToCanvasSize: unityProps.matchWebGLToCanvasSize || true,
+      matchWebGLToCanvasSize:
+        typeof unityProps.matchWebGLToCanvasSize !== "undefined"
+          ? unityProps.matchWebGLToCanvasSize
+          : true,
 
       // Assigns the disabled canvas events to the Unity arguments object. If
       // the disabled canvas events are not defined via the Unity Props, the

--- a/module/source/hooks/use-unity-arguments.ts
+++ b/module/source/hooks/use-unity-arguments.ts
@@ -52,7 +52,7 @@ const useUnityArguments = (unityProps: UnityProps): UnityArguments => {
       // object. If the match WebGL to canvas size value is not defined via the
       // Unity Props, the default value of `true` will be used.
       matchWebGLToCanvasSize:
-        typeof unityProps.matchWebGLToCanvasSize !== "undefined"
+        typeof unityProps.matchWebGLToCanvasSize === "boolean"
           ? unityProps.matchWebGLToCanvasSize
           : true,
 


### PR DESCRIPTION
In this PR we try to fix a matchWebGLToCanvasSize issue. This prop was always set to true event if we set it to false via <Unity matchWebGLToCanvasSize={false}/>. That's because in /hooks/use-unity-arguments.ts the matchWebGLToCanvasSize was being set with an OR operator which was always resulting to true. 
Here is a screenshot of the only in-code change applied. By checking if the type is boolean we make sure that no other types like 'string' or 'undefined' are coming in, but if so, true should be the default value.

<img width="771" alt="Screenshot 2023-05-29 at 5 05 12 PM" src="https://github.com/jeffreylanters/react-unity-webgl/assets/44381101/0518b265-0d9c-4225-a58d-5cc64ad9141a">
