### PR TITLE
docs: update create-react-app recommendation to vite

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Thanks for your time, happy coding!
 
 # Installation
 
-Get started by installing React Unity WebGL using the Node Package Manager or Yarn in your JavaScript or TypeScript React project. If you don't have a React project yet, I recommend using [Creat-React-App](https://reactjs.org/docs/create-a-new-react-app.html) to get you started right away. Visit the [installation documentation](https://react-unity-webgl.dev/docs/getting-started/installation) for more information.
+Get started by installing React Unity WebGL using the Node Package Manager or Yarn in your JavaScript or TypeScript React project. If you don't have a React project yet, I recommend using [Vite React template](https://vitejs.dev/guide/) to get you started right away. Visit the [installation documentation](https://react-unity-webgl.dev/docs/getting-started/installation) for more information.
 
 Before installing the module, make sure you're installing a version which is compatible with your build's Unity version. When a new Unity version releases, I'll update the module as soon as possible in order to keep the compatibility up to date. If you are running into any issues, please consider [opening an issue](https://github.com/jeffreylanters/react-unity-webgl/issues/new/choose).
 

--- a/documentation/docs/getting-started/hello-world.md
+++ b/documentation/docs/getting-started/hello-world.md
@@ -1,6 +1,6 @@
 # Hello World
 
-It's easy and simple to get your first React Unity WebGL project up-and-running. Just make sure you have your Unity WebGL build ready, and have your React project all set up. If it's your first time working with React, I recommend checking out [Create React App](https://reactjs.org/docs/create-a-new-react-app.html).
+It's easy and simple to get your first React Unity WebGL project up-and-running. Just make sure you have your Unity WebGL build ready, and have your React project all set up. If it's your first time working with React, I recommend checking out [Vite React template](https://vitejs.dev/guide/).
 
 Get started by importing the Unity Component and Unity Context hook from the module. A basic implementation of the Unity Context Hook only requires some basic configuration. While it is taking care of everything complicated such as communication, event listeners and references internally, all we're interested in is the Unity Provider spit out by the hook. We're going to pass down this object in order to render the configured Unity Application.
 

--- a/documentation/docs/getting-started/installation.md
+++ b/documentation/docs/getting-started/installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-Get started by installing React Unity WebGL using the Node Package Manager or Yarn in your JavaScript or TypeScript React project. If you don't have a React project yet, I recommend using [Creat React App](https://reactjs.org/docs/create-a-new-react-app.html) to get you started right away.
+Get started by installing React Unity WebGL using the Node Package Manager or Yarn in your JavaScript or TypeScript React project. If you don't have a React project yet, I recommend using [Vite React template](https://vitejs.dev/guide/) to get you started right away.
 
 :::tip
 Before installing the module, make sure you're installing a version which is compatible with your build's Unity version. When a new Unity version releases, I'll update the module as soon as possible in order to keep the compatibility. If you are running into any issues, please open an issue on the [React Unity WebGL Github page](https://github.com/jeffreylanters/react-unity-webgl/issues).

--- a/documentation/versioned_docs/version-8.x.x/getting-started.md
+++ b/documentation/versioned_docs/version-8.x.x/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-It's easy and quick to get your first React Unity project up-and-running. Just make sure you have your Unity WebGL build ready, and have your React project all set up. There are no specific React requirements, any project will do. If it's the first time working with React, I recommend checking out [Create React App](https://reactjs.org/docs/create-a-new-react-app.html). Both JavaScript and TypeScript are compatible.
+It's easy and quick to get your first React Unity project up-and-running. Just make sure you have your Unity WebGL build ready, and have your React project all set up. There are no specific React requirements, any project will do. If it's the first time working with React, I recommend checking out [Vite React template](https://vitejs.dev/guide/). Both JavaScript and TypeScript are compatible.
 
 Get started by import the Unity and Unity Context classes from the module. The Unity Context model will house all of your configuration, event listeners and references. Create a new Unity Context Object, pass along the paths to your Unity build and assign it to the Unity component in your Render Method. A basic implementation should look something like this.
 


### PR DESCRIPTION
## Documentation

This small PR removes outdated / deprecated [create-react-app](https://create-react-app.dev/docs/getting-started) from recommendation and replace with [Vite](https://vitejs.dev/guide/) instead.

For more information, see this [comment](https://github.com/reactjs/react.dev/pull/5487#issuecomment-1409720741).