### PR TITLE
Make print and printErr functions configurable

### DIFF
--- a/documentation/docs/api/logging-hooks.md
+++ b/documentation/docs/api/logging-hooks.md
@@ -1,0 +1,42 @@
+# Logging Hooks
+
+Intercept logs from the Unity module.
+
+## Type Definition
+
+```ts title="Type Definition"
+type UnityConfig = {
+  readonly print?: (message: string) => void;
+  readonly printErr?: (message: string) => void;
+};
+```
+
+## Implementation
+
+The `print` and `printErr` functions supplied in the `UnityConfig` will be passed verbatim to `createUnityInstance`. These functions will receive log messages coming from the Unity module - in particular, logs that would normally be printed to `stdout` or `stderr`.
+
+:::warning
+The messages received by these functions are distinct from the ones that are already printed to the console by default via `UnityEngine.Debug.Log` etc.
+:::
+
+## Example Usage
+
+Below is an example of using `print` and `printErr` to print module logs to the console.
+
+```jsx {10-11} showLineNumbers title="App.jsx"
+import React from "react";
+import { Unity, useUnityContext } from "react-unity-webgl";
+
+function App() {
+  const { unityProvider } = useUnityContext({
+    loaderUrl: "build/myunityapp.loader.js",
+    dataUrl: "build/myunityapp.data",
+    frameworkUrl: "build/myunityapp.framework.js",
+    codeUrl: "build/myunityapp.wasm",
+    print: console.log,
+    printErr: console.error,
+  });
+
+  return <Unity unityProvider={unityProvider} />;
+}
+```

--- a/documentation/sidebars.json
+++ b/documentation/sidebars.json
@@ -191,6 +191,11 @@
           "type": "doc",
           "id": "api/canvas-id",
           "label": "Custom Canvas ID"
+        },
+        {
+          "type": "doc",
+          "id": "api/logging-hooks",
+          "label": "Logging Hooks"
         }
       ]
     }

--- a/module/source/hooks/use-unity-arguments.ts
+++ b/module/source/hooks/use-unity-arguments.ts
@@ -66,27 +66,11 @@ const useUnityArguments = (unityProps: UnityProps): UnityArguments => {
 
       // Assigns the print hook to the Unity arguments object. This hook will
       // be called whenever the Unity instance prints a message.
-      print:
-        /**
-         * Intercept print events in order to catch messages and send them to
-         * the unity context instead.
-         * @param message The message to be printed.
-         */
-        (message: string) => {
-          // TODO -- Re-implement this hook.
-        },
+      print: unityProps.unityProvider.unityConfig.print,
 
       // Assigns the print error hook to the Unity arguments object. This hook
       // will be called whenever the Unity instance prints an error.
-      printErr:
-        /**
-         * Intercept print error events in order to catch messages and send them
-         * to the unity context instead.
-         * @param error The error to be printed.
-         */
-        (error: string) => {
-          // TODO -- Re-implement this hook.
-        },
+      printErr: unityProps.unityProvider.unityConfig.printErr,
     }),
     []
   );

--- a/module/source/types/unity-config.ts
+++ b/module/source/types/unity-config.ts
@@ -18,6 +18,8 @@ type ConfigurableUnityArguments = Pick<
   | "productVersion"
   | "webglContextAttributes"
   | "cacheControl"
+  | "print"
+  | "printErr"
 >;
 
 /**


### PR DESCRIPTION
This is a change that would expose `print` and `printErr` as configurable Unity arguments. I started a discussion regarding this change here: https://github.com/jeffreylanters/react-unity-webgl/discussions/547 but am hoping that this PR will have more visibility.