### PR TITLE
There are some typos in the examples in the documents

### DIFF
--- a/documentation/docs/api/take-screenshot.md
+++ b/documentation/docs/api/take-screenshot.md
@@ -22,7 +22,7 @@ In order to take screenshot of the Unity WebGL canvas, you'll need to enable pre
 
 ```jsx showLineNumbers title="Example: Preserving the Drawing Buffer"
 const unityContext = useUnityContext({
-  webGLContextAttributes: {
+  webglContextAttributes: {
     preserveDrawingBuffer: true,
   },
 });
@@ -60,7 +60,7 @@ function App() {
     dataUrl: "build/myunityapp.data",
     frameworkUrl: "build/myunityapp.framework.js",
     codeUrl: "build/myunityapp.wasm",
-    webGLContextAttributes: {
+    webglContextAttributes: {
       preserveDrawingBuffer: true,
     },
   });

--- a/documentation/docs/api/webgl-rendering-context.md
+++ b/documentation/docs/api/webgl-rendering-context.md
@@ -85,7 +85,7 @@ function App() {
     dataUrl: "build/myunityapp.data",
     frameworkUrl: "build/myunityapp.framework.js",
     codeUrl: "build/myunityapp.wasm",
-    webGLContextAttributes: {
+    webglContextAttributes: {
       alpha: true,
       antialias: true,
       depth: true,

--- a/documentation/versioned_docs/version-8.x.x/api/webgl-rendering-context.md
+++ b/documentation/versioned_docs/version-8.x.x/api/webgl-rendering-context.md
@@ -32,7 +32,7 @@ const unityContext = new UnityContext({
   dataUrl: "build/myunityapp.data",
   frameworkUrl: "build/myunityapp.framework.js",
   codeUrl: "build/myunityapp.wasm",
-  webGLContextAttributes: {
+  webglContextAttributes: {
     alpha: true,
     antialias: true,
     depth: true,


### PR DESCRIPTION

It may be an old API. I was trying the `takescreenshot`  feature but it was not working. Then I found `webGLContextAttributes` should be `webglContextAttributes`