### PR TITLE
Use script.remove instead of removeChild for unity loader hook

### DIFF
--- a/module/source/hooks/use-unity-loader.ts
+++ b/module/source/hooks/use-unity-loader.ts
@@ -3,6 +3,16 @@ import { isBrowserEnvironment } from "../constants/is-browser-environment";
 import { UnityLoaderStatus } from "../enums/unity-loader-status";
 import { UnityConfig } from "../exports";
 
+interface ScriptData {
+  count: number;
+  status: UnityLoaderStatus;
+  handleLoad?: () => void;
+  handleError?: () => void;
+}
+
+// Map to track script references, status, and event handlers.
+const scriptReferenceMap = new Map<string, ScriptData>();
+
 /**
  * Hook to embed a Unity Loader script.
  * @param source The source of the unity loader.
@@ -18,12 +28,12 @@ const useUnityLoader = (unityConfig: UnityConfig): UnityLoaderStatus => {
     // this scenario, the window is not available. We can't create a Unity
     // Loader in this case.
     if (isBrowserEnvironment === false) {
-      return;
+      return undefined;
     }
     // If the script's source is null, we'll reset the status to idle.
     if (unityConfig.loaderUrl === null) {
       setStatus(UnityLoaderStatus.Idle);
-      return;
+      return undefined;
     }
     /**
      * Find existing script element by source. It may have been added by
@@ -78,7 +88,7 @@ const useUnityLoader = (unityConfig: UnityConfig): UnityLoaderStatus => {
       if (script !== null) {
         script.removeEventListener("load", setStateFromEvent);
         script.removeEventListener("error", setStateFromEvent);
-        window.document.body.removeChild(script);
+        script.remove();
       }
     };
   }, [unityConfig.loaderUrl]);

--- a/module/source/hooks/use-unity-loader.ts
+++ b/module/source/hooks/use-unity-loader.ts
@@ -18,12 +18,12 @@ const useUnityLoader = (unityConfig: UnityConfig): UnityLoaderStatus => {
     // this scenario, the window is not available. We can't create a Unity
     // Loader in this case.
     if (isBrowserEnvironment === false) {
-      return;
+      return undefined;
     }
     // If the script's source is null, we'll reset the status to idle.
     if (unityConfig.loaderUrl === null) {
       setStatus(UnityLoaderStatus.Idle);
-      return;
+      return undefined;
     }
     /**
      * Find existing script element by source. It may have been added by
@@ -78,7 +78,7 @@ const useUnityLoader = (unityConfig: UnityConfig): UnityLoaderStatus => {
       if (script !== null) {
         script.removeEventListener("load", setStateFromEvent);
         script.removeEventListener("error", setStateFromEvent);
-        window.document.body.removeChild(script);
+        script.remove();
       }
     };
   }, [unityConfig.loaderUrl]);

--- a/module/source/hooks/use-unity-loader.ts
+++ b/module/source/hooks/use-unity-loader.ts
@@ -3,16 +3,6 @@ import { isBrowserEnvironment } from "../constants/is-browser-environment";
 import { UnityLoaderStatus } from "../enums/unity-loader-status";
 import { UnityConfig } from "../exports";
 
-interface ScriptData {
-  count: number;
-  status: UnityLoaderStatus;
-  handleLoad?: () => void;
-  handleError?: () => void;
-}
-
-// Map to track script references, status, and event handlers.
-const scriptReferenceMap = new Map<string, ScriptData>();
-
 /**
  * Hook to embed a Unity Loader script.
  * @param source The source of the unity loader.
@@ -28,12 +18,12 @@ const useUnityLoader = (unityConfig: UnityConfig): UnityLoaderStatus => {
     // this scenario, the window is not available. We can't create a Unity
     // Loader in this case.
     if (isBrowserEnvironment === false) {
-      return undefined;
+      return;
     }
     // If the script's source is null, we'll reset the status to idle.
     if (unityConfig.loaderUrl === null) {
       setStatus(UnityLoaderStatus.Idle);
-      return undefined;
+      return;
     }
     /**
      * Find existing script element by source. It may have been added by
@@ -88,7 +78,7 @@ const useUnityLoader = (unityConfig: UnityConfig): UnityLoaderStatus => {
       if (script !== null) {
         script.removeEventListener("load", setStateFromEvent);
         script.removeEventListener("error", setStateFromEvent);
-        script.remove();
+        window.document.body.removeChild(script);
       }
     };
   }, [unityConfig.loaderUrl]);


### PR DESCRIPTION
Key changes:

* Updated the return value for non-browser environments and null loader URLs to `undefined` instead of an implicit return.
* Simplified script element removal by using the `remove` method instead of `window.document.body.removeChild`. Previous version would produce error if the node was not present, i.e. when unloading multiple instances.